### PR TITLE
fix: prevent gesture conflict due to quick scale and draw strokes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed unintended zoom when drawing quickly ([#106])
 
 ## [1.1.1] - 2025-07-17
 ### Changed
@@ -29,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 
 [#76]: https://github.com/FossifyOrg/Paint/issues/76
+[#106]: https://github.com/FossifyOrg/Paint/issues/106
 
 [Unreleased]: https://github.com/FossifyOrg/Paint/compare/1.1.1...HEAD
 [1.1.1]: https://github.com/FossifyOrg/Paint/compare/1.1.0...1.1.1

--- a/app/src/main/kotlin/org/fossify/paint/views/MyCanvas.kt
+++ b/app/src/main/kotlin/org/fossify/paint/views/MyCanvas.kt
@@ -89,7 +89,10 @@ class MyCanvas(context: Context, attrs: AttributeSet) : View(context, attrs) {
             isAntiAlias = true
         }
 
-        mScaleDetector = ScaleGestureDetector(context, ScaleListener())
+        mScaleDetector = ScaleGestureDetector(context, ScaleListener()).apply {
+            isQuickScaleEnabled = false
+        }
+
         updateUndoVisibility()
     }
 


### PR DESCRIPTION

<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
- Disabled quick scale gesture because it conflicts with draw strokes as described in #106.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested quick scaling (disabled state)
 - Tested pinch-to-zoom gesture

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes #106

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
