### PR TITLE
fix: crop SVG export to the visible canvas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed SVG export not being cropped to the visible area after the canvas was moved or zoomed ([#26])
 
 ## [1.4.0] - 2026-01-30
 ### Added
@@ -54,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[#26]: https://github.com/FossifyOrg/Paint/issues/26
 [#76]: https://github.com/FossifyOrg/Paint/issues/76
 [#106]: https://github.com/FossifyOrg/Paint/issues/106
 [#119]: https://github.com/FossifyOrg/Paint/issues/119

--- a/app/src/main/kotlin/org/fossify/paint/actions/Action.kt
+++ b/app/src/main/kotlin/org/fossify/paint/actions/Action.kt
@@ -1,5 +1,6 @@
 package org.fossify.paint.actions
 
+import android.graphics.Matrix
 import android.graphics.Path
 import java.io.Serializable
 import java.io.Writer
@@ -7,5 +8,5 @@ import java.io.Writer
 interface Action : Serializable {
     fun perform(path: Path)
 
-    fun perform(writer: Writer)
+    fun perform(writer: Writer, transform: Matrix)
 }

--- a/app/src/main/kotlin/org/fossify/paint/actions/Line.kt
+++ b/app/src/main/kotlin/org/fossify/paint/actions/Line.kt
@@ -1,5 +1,6 @@
 package org.fossify.paint.actions
 
+import android.graphics.Matrix
 import android.graphics.Path
 import java.io.Writer
 import java.security.InvalidParameterException
@@ -34,7 +35,9 @@ class Line : Action {
         path.lineTo(x, y)
     }
 
-    override fun perform(writer: Writer) {
-        writer.write("L$x,$y")
+    override fun perform(writer: Writer, transform: Matrix) {
+        val points = floatArrayOf(x, y)
+        transform.mapPoints(points)
+        writer.write("L${points[0]},${points[1]}")
     }
 }

--- a/app/src/main/kotlin/org/fossify/paint/actions/Move.kt
+++ b/app/src/main/kotlin/org/fossify/paint/actions/Move.kt
@@ -1,5 +1,6 @@
 package org.fossify.paint.actions
 
+import android.graphics.Matrix
 import android.graphics.Path
 import java.io.Writer
 import java.security.InvalidParameterException
@@ -32,7 +33,9 @@ class Move : Action {
         path.moveTo(x, y)
     }
 
-    override fun perform(writer: Writer) {
-        writer.write("M$x,$y")
+    override fun perform(writer: Writer, transform: Matrix) {
+        val points = floatArrayOf(x, y)
+        transform.mapPoints(points)
+        writer.write("M${points[0]},${points[1]}")
     }
 }

--- a/app/src/main/kotlin/org/fossify/paint/actions/Quad.kt
+++ b/app/src/main/kotlin/org/fossify/paint/actions/Quad.kt
@@ -1,5 +1,6 @@
 package org.fossify.paint.actions
 
+import android.graphics.Matrix
 import android.graphics.Path
 import java.io.Writer
 import java.security.InvalidParameterException
@@ -43,7 +44,11 @@ class Quad : Action {
         path.quadTo(x1, y1, x2, y2)
     }
 
-    override fun perform(writer: Writer) {
-        writer.write("Q$x1,$y1 $x2,$y2")
+    override fun perform(writer: Writer, transform: Matrix) {
+        val control = floatArrayOf(x1, y1)
+        val end = floatArrayOf(x2, y2)
+        transform.mapPoints(control)
+        transform.mapPoints(end)
+        writer.write("Q${control[0]},${control[1]} ${end[0]},${end[1]}")
     }
 }

--- a/app/src/main/kotlin/org/fossify/paint/models/Svg.kt
+++ b/app/src/main/kotlin/org/fossify/paint/models/Svg.kt
@@ -1,6 +1,7 @@
 package org.fossify.paint.models
 
 import android.graphics.Color
+import android.graphics.Matrix
 import android.graphics.drawable.ColorDrawable
 import android.net.Uri
 import android.sax.RootElement
@@ -37,7 +38,15 @@ object Svg {
         if (outputStream != null) {
             val backgroundColor = (canvas.background as ColorDrawable).color
             val writer = BufferedWriter(OutputStreamWriter(outputStream))
-            writeSvg(writer, backgroundColor, canvas.getPathsMap(), canvas.width, canvas.height)
+            writeSvg(
+                writer,
+                backgroundColor,
+                canvas.getPathsMap(),
+                canvas.width,
+                canvas.height,
+                canvas.getCanvasTransform(),
+                canvas.getScaleFactor()
+            )
             writer.close()
             activity.toast(R.string.file_saved)
         } else {
@@ -50,7 +59,9 @@ object Svg {
         backgroundColor: Int,
         paths: Map<MyPath, PaintOptions>,
         width: Int,
-        height: Int
+        height: Int,
+        transform: Matrix,
+        scaleFactor: Float
     ) {
         writer.apply {
             write("<svg width=\"$width\" height=\"$height\" xmlns=\"http://www.w3.org/2000/svg\">")
@@ -63,24 +74,30 @@ object Svg {
             )
 
             for ((key, value) in paths) {
-                writePath(this, key, value)
+                writePath(this, key, value, transform, scaleFactor)
             }
             write("</svg>")
         }
     }
 
-    private fun writePath(writer: Writer, path: MyPath, options: PaintOptions) {
+    private fun writePath(
+        writer: Writer,
+        path: MyPath,
+        options: PaintOptions,
+        transform: Matrix,
+        scaleFactor: Float
+    ) {
         writer.apply {
             write("<path d=\"")
             path.actions.forEach {
-                it.perform(this)
+                it.perform(this, transform)
                 write(" ")
             }
 
             write("\" fill=\"none\" stroke=\"")
             write(options.getColorToExport())
             write("\" stroke-width=\"")
-            write(options.strokeWidth.toString())
+            write((options.strokeWidth * scaleFactor).toString())
             write("\" stroke-linecap=\"round\"/>")
         }
     }

--- a/app/src/main/kotlin/org/fossify/paint/views/MyCanvas.kt
+++ b/app/src/main/kotlin/org/fossify/paint/views/MyCanvas.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Matrix
 import android.graphics.Paint
 import android.graphics.Point
 import android.graphics.PointF
@@ -452,6 +453,17 @@ class MyCanvas(context: Context, attrs: AttributeSet) : View(context, attrs) {
     }
 
     fun getPathsMap() = mOperations
+
+    fun getScaleFactor() = mScaleFactor
+
+    // the pan/zoom transform currently applied in onDraw, so exports can match the visible area
+    fun getCanvasTransform(): Matrix {
+        val center = mCenter ?: PointF(width / 2f, height / 2f)
+        return Matrix().apply {
+            postScale(mScaleFactor, mScaleFactor, center.x, center.y)
+            postTranslate(mPosX, mPosY)
+        }
+    }
 
     fun getDrawingHashCode(): Long {
         return if (mOperations.isEmpty()) {


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
The raster (PNG/JPG) export path goes through `MyCanvas.getBitmap()`, which draws the canvas via `onDraw()` and therefore bakes in the current pan/zoom (`canvas.translate(mPosX, mPosY)` + `canvas.scale(mScaleFactor, mScaleFactor, mCenter)`). The output is correctly cropped to what is visible at save time.

The SVG export path (`Svg.saveToOutputStream` -> `writeSvg`) instead wrote each path's raw recorded coordinates with the viewport width/height and no transform. As a result a saved SVG reflected the launch-time coordinate space rather than the currently visible viewport, so it appeared wrongly cropped after the canvas had been moved or zoomed, exactly as the reporter describes.

This change reproduces, in the SVG writer, the same pan/zoom matrix that `onDraw` applies (scale-about-center then translate) and bakes it into every exported coordinate via `Matrix.mapPoints`. Stroke widths are multiplied by the current scale factor to match the raster output (where `canvas.scale` also scales stroke widths). The `<path>` elements stay direct children of `<svg>` (flat structure), so the app's own `parseSvg` loader is unchanged and re-opening a saved SVG round-trips exactly. The background `<rect>` is intentionally left untransformed since it fills the whole viewport in both raster and SVG. When there is no pan and `scaleFactor == 1`, the matrix is identity and the stroke-width multiplier is 1, so the output is byte-identical to before (backward compatible).

#### Tests performed
- `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).
- Source-verified: SVG export now applies the same canvas `Matrix` transform to each drawn action's coordinates that the raster (PNG/JPG) export already uses, so the exported SVG is cropped to the visible/moved canvas instead of the initial bounds.
- Note: verified via CI + code review; the draw-move-export flow was not scripted end-to-end.

#### Closes the following issue(s)
- Closes #26

#### Checklist
- [x] I read the contribution guidelines.
- [ ] I manually tested my changes on device/emulator (verified via CI + source review; see Tests performed).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
